### PR TITLE
Resolve issue with int type of field '_id'

### DIFF
--- a/emploi_store/__init__.py
+++ b/emploi_store/__init__.py
@@ -224,7 +224,7 @@ class Resource(object):
                 csvfile, fieldnames, extrasaction='ignore')
             csv_writer.writeheader()
             for record in records:
-                record = {_strip_bom(k): v for k, v in record.items()}
+                record = {_strip_bom(k): unicode(v) for k, v in record.items()}
                 if need_utf8_encode:
                     record = {
                         k.encode('utf-8'): v.encode('utf-8')


### PR DESCRIPTION
with Python 2.7, solves issue that int type of field '_id' does not have encode method. (even though the _id field is not in fieldnames, the dictwriter still evaluates the values of the _id field, and they are ints - the encode method only exists for type string